### PR TITLE
from feature/update readme.md to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # moony
 
-## Phase 1: Reactor 模型的理解与其在 muduo 中对应的组件
+## Phase 1: Reactor 模式的理解与其在 muduo 中对应的组件
+首先 Reactor 模式中，每一个线程（thread）对应一个事件循环（event loop），每一个事件循环对应一个I/O复用接口（select、poll、epoll），每一个I/O复用接口监听多个文件描述符（fd），而一个事件（event）对应一个 fd，也就是说，一个I/O复用接口监听多个该线程感兴趣的事件。<br>
+
+对应到 muduo 中的组件，我们可以发现：<br>
+
+### channel 类
+事实上 channel 类中封装了 fd 和其感兴趣的事件的类型，如EPOLLIN、EPOLLOUT，封装了各类事件的回调，还封装了一个 poller 用于监听 fd 上发生的事件。通过这个描述不难发现其实它对应的是 Reactor 模式中的事件（event），它通过 enable_reading() 等接口向 I/O 复用接口中注册事件，通过 handle_event() 接口调用事件的回调函数处理事件。channel 在析构之前要调用 event_loop::remove_channel()，避免悬空指针。
+
+### poller 类
+poller 类是对 I/O 复用接口的一层抽象封装，定义成了一个抽象基类，后面可以实现 epoll_poller、poll_poller 等 poller。当用户通过 channel::enable_reading() 向 poller 中注册事件的时候，会通过event_loop::update_channel() 调用 channel::update()。显然 poller 类中应该维护一个 std::map<channel*> 类型的字典，以存放 poller 感兴趣的 channel。
+
+### epoll_poller 类
+poller 的派生类。epoll_poller 类是基于 epoll 实现的一个 poller，其核心是 epoll_poller::poll_wait()，里面调用了 epoll_wait()。而 poller::update() 会再调用到 epoll_poller::update_channel()，最后调用到 epoll_poller::update() 执行最终的 ::epoll_ctl() 调用，实现事件的注册和注销。
+
+### event_loop 类

--- a/net/poller/epoll_poller.cc
+++ b/net/poller/epoll_poller.cc
@@ -10,7 +10,7 @@
 namespace {
     const int k_new = -1; // channel 未添加到 poller 中
     const int k_added = 1;  // channel 已添加到 poller 中
-    const int k_deled = 2;  // channel 从 poller 中删除
+    const int k_deleted = 2;  // channel 从 poller 中删除
 }
 
 lee::epoll_poller::epoll_poller(event_loop* loop): 
@@ -64,7 +64,7 @@ void lee::epoll_poller::update_channel(channel* chann) {
     LOG_FMT_INFO("func = %s -> fd = %d, events = %d, index = %d\n", 
             __FUNCTION__, chann->fd(), chann->events(), chann->index());
 
-    if (index == k_new || index == k_deled) {
+    if (index == k_new || index == k_deleted) {
         if (index == k_new) {
             channels_[fd] = chann;
         }
@@ -73,7 +73,7 @@ void lee::epoll_poller::update_channel(channel* chann) {
     } else {
         if (chann->is_none_event()) {    
             update(EPOLL_CTL_DEL, chann);
-            chann->set_index(k_deled);
+            chann->set_index(k_deleted);
         } else {
             update(EPOLL_CTL_MOD, chann);
         }


### PR DESCRIPTION
更新了：
1. epoll_poller.cc 中关于 channel 是否已经注销的常量名从 k_deled 改为 k_deleted；
2. 项目根目录下的README.md文件，添加了关于 channel、poller、epoll_poller三个类的描述以及其对应 Reactor 模式的组件。